### PR TITLE
Adding check_sample function

### DIFF
--- a/sandboxapi/cuckoo.py
+++ b/sandboxapi/cuckoo.py
@@ -79,6 +79,26 @@ class CuckooAPI(sandboxapi.SandboxAPI):
 
         return False
 
+    def check_sample(self, hash_type, sample_hash):
+        """Check if a sample has been previously submitted.
+
+        @type   sample_hash:   str
+        @param  sample_hash:   MD5 or SHA256 hash to check for.
+        @type   hash_type:     str
+        @param  hash_type:     Hash type as either MD5 or SHA256.
+
+        @rtype:     int
+        @return:    Submission ID of the sample or None if not present.
+        """
+        try:
+            response = self._request("files/view/{htype}/{hvalue}".format(htype=hash_type, hvalue=sample_hash))
+            item_id = response.json()['sample']['id']
+
+        except sandboxapi.SandboxError:
+            item_id = None 
+
+        return item_id
+
     def delete(self, item_id):
         """Delete the reports associated with the given item_id.
 

--- a/sandboxapi/vmray.py
+++ b/sandboxapi/vmray.py
@@ -75,6 +75,26 @@ class VMRayAPI(sandboxapi.SandboxAPI):
 
         return False
 
+    def check_sample(self, hash_type, sample_hash):
+        """Check if a sample has been previously submitted.
+
+        @type   sample_hash:   str
+        @param  sample_hash:   MD5, SHA1 or SHA256 hash to check for.
+        @type   hash_type:     str
+        @param  hash_type:     Hash type as either MD5, SHA1 or SHA256.
+
+        @rtype:     int
+        @return:    Submission ID of the sample or None if not present.
+        """
+        response = self._request("/sample/{htype}/{hvalue}".format(htype=hash_type, hvalue=sample_hash), headers=self.headers)
+        
+        item_id = None
+        for submission in response.json()['data']:
+            item_id = item_id or submission['sample_id']
+        
+        return item_id
+
+
     def is_available(self):
         """Determine if the VMRay API server is alive.
 


### PR DESCRIPTION
I thought it would be useful to allow the checking of sandboxes to determine if a sample had previously been submitted, by querying the hash value, returning the Submission ID or None if not present.

I am looking at implementing the same for Fireeye but do not have the API documentation available right now.

NOTE: Cuckoo supports md5 and sha256 for the query only, whereas VMRay supports md5, sha1 & sha256. The respective hash type must be passed when calling the function.

Thanks for considering this PR, please do not hesitate to come back with any queries!