### PR TITLE
Falcon is_available() fix

### DIFF
--- a/sandboxapi/falcon.py
+++ b/sandboxapi/falcon.py
@@ -114,12 +114,19 @@ class FalconAPI(sandboxapi.SandboxAPI):
         else:
 
             try:
+                # Try the on-prem endpoint.
                 response = self._request("/system/heartbeat")
 
                 # we've got falcon.
                 if response.status_code == 200:
                     self.server_available = True
                     return True
+                elif response.status_code == 403:
+                    # Try the public sandbox endpoint.
+                    response = self._request("/system/version")
+                    if response.status_code == 200:
+                        self.server_available = True
+                        return True
 
             except sandboxapi.SandboxError:
                 pass


### PR DESCRIPTION
Added logic to is_available() to try the public sandbox endpoint if the on-prem endpoint fails.

#8 